### PR TITLE
Publish doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Generate and publish Android Matrix SDK documentation
+name: Documentation
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   docs:
-    name: Docs
+    name: Generate and publish Android Matrix SDK documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Generate and publish Android Matrix SDK documentation
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build docs
+        run: ./gradlew dokkaHtml
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./matrix-sdk-android/build/dokka/html

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ implementation 'org.matrix.android:matrix-android-sdk2:1.2.1'
 
 Latest version: ![Latest version](https://img.shields.io/maven-central/v/org.matrix.android/matrix-android-sdk2)
 
+### API documentation
+
+The Matrix Android SDK2 API documentation can be found here: https://matrix-org.github.io/matrix-android-sdk2
+
+We are currently working to improve it.
+
 ### Sample application
 
 You can have a look on the sample app we have written to help starting with the new SDK: https://github.com/matrix-org/matrix-android-sdk2-sample.

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -164,6 +164,7 @@ ext.groups = [
                         'org.codehaus.woodstox',
                         'org.eclipse.ee4j',
                         'org.ec4j.core',
+                        'org.freemarker',
                         'org.glassfish.jaxb',
                         'org.hamcrest',
                         'org.jacoco',


### PR DESCRIPTION
This PR configures a GH action to build with `dokka` and publish in GH pages the SDK api documentation. This action will be triggered each time a push is done on `main`, i.e. each time we release the SDK.

Generated documentation is available here: https://matrix-org.github.io/matrix-android-sdk2/

Next step is to improve the generated documentation, and this will be done in Element Android project.