### PR TITLE
Upgrade maven publishing to use Maven Central Portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -49,4 +51,18 @@ allprojects {
         // Ignore on the SDK for the moment
         kotlinOptions.allWarningsAsErrors = false
     }
+
+
+    plugins.withId("com.vanniktech.maven.publish") {
+        // Publish on s01.oss.sonatype.org
+        //https://github.com/vanniktech/gradle-maven-publish-plugin#where-to-upload-to
+        mavenPublishing {
+            publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        }
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath libs.gradle.gradlePlugin
         classpath libs.gradle.kotlinPlugin
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.18.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.32.0'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -49,16 +49,4 @@ allprojects {
         // Ignore on the SDK for the moment
         kotlinOptions.allWarningsAsErrors = false
     }
-
-    plugins.withId("com.vanniktech.maven.publish") {
-        // Publish on s01.oss.sonatype.org
-        //https://github.com/vanniktech/gradle-maven-publish-plugin#where-to-upload-to
-        mavenPublish {
-            sonatypeHost = "S01"
-        }
-    }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -1,5 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -158,10 +156,6 @@ static def gitRevisionDate() {
 
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 }
 
 dependencies {

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -156,6 +158,10 @@ static def gitRevisionDate() {
 
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 }
 
 dependencies {


### PR DESCRIPTION
- Upgrade maven publishing plugin to `v0.32.0`.
- Change the `SonatypeHost` to point to `CENTRAL_PORTAL`.